### PR TITLE
Feat/#10 user 닉네임, 전화번호 등록

### DIFF
--- a/src/main/java/konkuk/tourkk/chons/domain/user/application/UserService.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/application/UserService.java
@@ -1,16 +1,23 @@
 package konkuk.tourkk.chons.domain.user.application;
 
+import java.util.Optional;
+import konkuk.tourkk.chons.domain.user.application.req.AdditionalInfoRequest;
+import konkuk.tourkk.chons.domain.user.application.res.AdditionalInfoResponse;
 import konkuk.tourkk.chons.domain.user.domain.entity.User;
 import konkuk.tourkk.chons.domain.user.domain.enums.Role;
 import konkuk.tourkk.chons.domain.user.domain.enums.SocialType;
+import konkuk.tourkk.chons.domain.user.exception.UserException;
 import konkuk.tourkk.chons.domain.user.infrastructure.UserRepository;
 import konkuk.tourkk.chons.global.auth.presentation.dto.req.LoginRequest;
+import konkuk.tourkk.chons.global.exception.properties.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
@@ -24,5 +31,19 @@ public class UserService {
             .name(name)
             .build();
         return userRepository.save(user);
+    }
+
+    public AdditionalInfoResponse addMoreInfo(Long userId, AdditionalInfoRequest request) {
+        User user = findById(userId);
+        user.changeNickname(request.getNickname());
+        user.changePhoneNum(request.getPhoneNum());
+
+        return AdditionalInfoResponse.of(user.getId(), user.getNickname(), user.getPhoneNum());
+    }
+
+    private User findById(Long id) {
+        Optional<User> userOptional = userRepository.findById(id);
+        return userOptional
+            .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/konkuk/tourkk/chons/domain/user/application/req/AdditionalInfoRequest.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/application/req/AdditionalInfoRequest.java
@@ -1,0 +1,16 @@
+package konkuk.tourkk.chons.domain.user.application.req;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdditionalInfoRequest {
+
+    private String nickname;
+
+    private String phoneNum;
+}

--- a/src/main/java/konkuk/tourkk/chons/domain/user/application/res/AdditionalInfoResponse.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/application/res/AdditionalInfoResponse.java
@@ -1,0 +1,21 @@
+package konkuk.tourkk.chons.domain.user.application.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdditionalInfoResponse {
+
+    Long userId;
+    String nickname;
+    String phoneNum;
+
+    public static AdditionalInfoResponse of(Long userId, String nickname, String phoneNum) {
+        return AdditionalInfoResponse.builder()
+            .userId(userId)
+            .nickname(nickname)
+            .phoneNum(phoneNum)
+            .build();
+    }
+}

--- a/src/main/java/konkuk/tourkk/chons/domain/user/domain/entity/User.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/domain/entity/User.java
@@ -69,6 +69,14 @@ public class User implements UserDetails {
         this.socialType = socialType;
     }
 
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void changePhoneNum(String phoneNum) {
+        this.phoneNum = phoneNum;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.getKey()));

--- a/src/main/java/konkuk/tourkk/chons/domain/user/exception/UserException.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/exception/UserException.java
@@ -1,0 +1,15 @@
+package konkuk.tourkk.chons.domain.user.exception;
+
+import konkuk.tourkk.chons.global.exception.exceptionClass.CustomException;
+import konkuk.tourkk.chons.global.exception.properties.ErrorCode;
+
+public class UserException extends CustomException {
+
+    public UserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UserException(ErrorCode errorCode, String runtimeValue) {
+        super(errorCode, runtimeValue);
+    }
+}

--- a/src/main/java/konkuk/tourkk/chons/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/konkuk/tourkk/chons/domain/user/presentation/controller/UserController.java
@@ -1,7 +1,14 @@
 package konkuk.tourkk.chons.domain.user.presentation.controller;
 
+import konkuk.tourkk.chons.domain.user.application.UserService;
+import konkuk.tourkk.chons.domain.user.application.req.AdditionalInfoRequest;
+import konkuk.tourkk.chons.domain.user.application.res.AdditionalInfoResponse;
+import konkuk.tourkk.chons.domain.user.domain.entity.User;
 import konkuk.tourkk.chons.global.auth.presentation.dto.req.LoginRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,5 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+@Slf4j
 public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/additional")
+    public ResponseEntity<AdditionalInfoResponse> addInfo(@AuthenticationPrincipal User user,
+                                                    @RequestBody AdditionalInfoRequest request) {
+        log.info("id: " + user.getId());
+        return ResponseEntity.ok(userService.addMoreInfo(user.getId(), request));
+    }
 }

--- a/src/main/java/konkuk/tourkk/chons/global/auth/application/AuthService.java
+++ b/src/main/java/konkuk/tourkk/chons/global/auth/application/AuthService.java
@@ -24,15 +24,16 @@ public class AuthService {
     public LoginResponse login(LoginRequest request) {
         String accessToken = jwtService.createAccessToken(request.getEmail());
         String refreshToken = jwtService.createRefreshToken();
-        Optional<User> user = userRepository.findByEmail(request.getEmail());
+        Optional<User> userOptional = userRepository.findByEmail(request.getEmail());
 
-        if(user.isEmpty()) {
-            userService.registerUser(request.getName(), request.getEmail(),
+        if(userOptional.isEmpty()) {
+            User newUser = userService.registerUser(request.getName(), request.getEmail(),
                 request.getSocialId(), request.getSocialType(),
                 Role.USER);
-            return LoginResponse.of(accessToken, refreshToken, request.getEmail(), false);
+            return LoginResponse.of(newUser.getId(), accessToken, refreshToken, request.getEmail(), false);
         }
 
-        return LoginResponse.of(accessToken, refreshToken, request.getEmail(), true);
+        User user = userOptional.get();
+        return LoginResponse.of(user.getId(), accessToken, refreshToken, user.getEmail(), true);
     }
 }

--- a/src/main/java/konkuk/tourkk/chons/global/auth/presentation/dto/res/LoginResponse.java
+++ b/src/main/java/konkuk/tourkk/chons/global/auth/presentation/dto/res/LoginResponse.java
@@ -9,11 +9,13 @@ public class LoginResponse {
 
     private String accessToken;
     private String refreshToken;
+    private Long userId;
     private String email;
     private boolean isJoined;
 
-    public static LoginResponse of(String accessToken, String refreshToken, String email, boolean isJoined) {
+    public static LoginResponse of(Long userId, String accessToken, String refreshToken, String email, boolean isJoined) {
         return LoginResponse.builder()
+            .userId(userId)
             .accessToken(accessToken)
             .refreshToken(refreshToken)
             .email(email)

--- a/src/main/java/konkuk/tourkk/chons/global/common/security/SecurityConfig.java
+++ b/src/main/java/konkuk/tourkk/chons/global/common/security/SecurityConfig.java
@@ -41,8 +41,9 @@ public class SecurityConfig {
                 httpSecuritySessionManagementConfigurer.sessionCreationPolicy(
                     SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/h2-console/*").permitAll()
-                .requestMatchers("/api/v1/auth/login").anonymous()
+                .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/api/v1/user/additional").authenticated()
+                .requestMatchers("/api/v1/**").anonymous()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll())
             .exceptionHandling(customizer -> customizer
                 .authenticationEntryPoint(customAuthenticationEntryPoint())

--- a/src/main/java/konkuk/tourkk/chons/global/exception/properties/ErrorCode.java
+++ b/src/main/java/konkuk/tourkk/chons/global/exception/properties/ErrorCode.java
@@ -3,6 +3,7 @@ package konkuk.tourkk.chons.global.exception.properties;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
@@ -22,6 +23,9 @@ public enum ErrorCode {
 
     // 403
     SECURITY_ACCESS_DENIED(FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404
+    USER_NOT_FOUND(NOT_FOUND, "user을 찾을 수 없습니다."),
 
     // 500
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생하였습니다.");


### PR DESCRIPTION
### 👀 관련 이슈

### ✨ 작업한 내용
- 최초 소셜 로그인 시 닉네임 전화번호를 소셜 서버에서 가져올 수 없어서 유저한테 받아야 합니다. 유저의 닉네임과 전화번호를 저장하는 기능을 구현했습니다.
- 로그인 성공 시 user id를 반환하도록 수정했습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
